### PR TITLE
feat: product data integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonzih/skills-product",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Claude Code skill suite for product managers and product owners",
   "type": "module",
   "bin": {

--- a/skills/prd-writer/SKILL.md
+++ b/skills/prd-writer/SKILL.md
@@ -32,3 +32,8 @@ Invite the user to review the draft. Offer to expand any section, add technical 
 
 ## Example outputs
 A complete PRD markdown document, typically 400–800 words, ready to paste into Notion, Confluence, or a GitHub issue. Sections are clearly headed and the open questions section flags blockers proactively.
+
+## Live Data Sources
+- **ProductHunt API** (`ph.com/api`) — Query competitor product listings and feature announcements to identify gaps and differentiation opportunities for the problem statement and scope sections.
+- **App Store Review RSS Feeds** — Pull recent user reviews for competitor apps to surface recurring pain points and unmet needs; use as evidence in the Problem Statement and Target Users sections.
+- **GitHub Issues & Discussions** — Mine open issues and discussion threads in open-source competitor repositories to identify feature requests, bugs users work around, and community sentiment.

--- a/skills/release-notes/SKILL.md
+++ b/skills/release-notes/SKILL.md
@@ -28,3 +28,8 @@ Assemble the full release notes document with the header, categorized changes, a
 
 ## Example outputs
 A formatted release notes document with a narrative header, categorized bullet points written in plain language, and a migration guide section if breaking changes are present. Suitable for a changelog page, email announcement, or in-app notification.
+
+## Live Data Sources
+- **GitHub Releases API** — Fetch release metadata, tag names, and associated commits directly from the repository to auto-populate version history and ensure no changes are missed.
+- **Keep a Changelog Format Standards** (`keepachangelog.com`) — Apply the canonical changelog format (Added / Changed / Deprecated / Removed / Fixed / Security) to ensure consistent, machine-readable structure across releases.
+- **Semantic Versioning Spec** (`semver.org`) — Validate version number increments (MAJOR.MINOR.PATCH) against the nature of changes to produce accurate, spec-compliant version bumps.

--- a/skills/roadmap-builder/SKILL.md
+++ b/skills/roadmap-builder/SKILL.md
@@ -33,3 +33,8 @@ Identify initiatives that must be completed before others can start. Produce a s
 
 ## Example outputs
 A roadmap document with a theme overview, a prioritized initiative table, and a dependency list. Optionally formatted as a now/next/later grid. Suitable for presenting in a planning meeting or embedding in a strategy doc.
+
+## Live Data Sources
+- **ProductHunt Trending Launches** (`ph.com/api`) — Monitor recently launched and trending products to identify emerging market patterns and time initiatives against category momentum.
+- **GitHub Star History API** (`star-history.com`) — Track star growth trajectories for open-source competitors to gauge traction, adoption curves, and when to prioritize defensive or offensive initiatives.
+- **Hacker News 'Ask HN' Pattern Mining** — Analyze recurring 'Ask HN' threads to surface unmet developer and builder needs that map to roadmap themes and initiatives.

--- a/skills/user-story-generator/SKILL.md
+++ b/skills/user-story-generator/SKILL.md
@@ -31,3 +31,7 @@ Order stories by business value and dependency chain. Group into a suggested spr
 
 ## Example outputs
 A numbered backlog of 8–15 user stories in a table or structured list, with each story fully specified and a sprint grouping at the end. Output is ready to copy into Jira, Linear, or any sprint planning tool.
+
+## Live Data Sources
+- **Intercom JTBD Research Frameworks** (`intercom.com/resources`) — Reference Jobs-to-be-Done interview guides and templates to ensure user stories are grounded in real job triggers, desired outcomes, and hire/fire criteria.
+- **Nielsen Norman Group Public Research** (`nngroup.com`) — Draw on published usability research, heuristics, and UX findings to validate personas and acceptance criteria against evidence-based design standards.


### PR DESCRIPTION
## Summary
- Adds `## Live Data Sources` section to all four skills (prd-writer, user-story-generator, roadmap-builder, release-notes)
- Each skill now references relevant external signals: ProductHunt API, App Store RSS, GitHub APIs, Intercom JTBD, NNG research, star-history.com, HN Ask HN, keepachangelog.com, semver spec
- Bumps package version to 1.1.0

Closes #1